### PR TITLE
don't link libbase64 but compile in src/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ TARGET=ncm2dump
 INCLUDE=-I./include/
 LIBS=-L./lib/ -lcjson -lpthread
 SRC=$(wildcard ./src/*.c)
-$TARGET:
+
+all:
 	$(CC) -o $(TARGET) $(INCLUDE) -O2 $(SRC) $(LIBS)
 
 clean:


### PR DESCRIPTION
Due to some error in linking libbase64.a. So compile it directly.